### PR TITLE
Showcase usage of Swift Testing instead of XCTest in example test file

### DIFF
--- a/Tests/MyLibraryTests/MyLibraryTests.swift
+++ b/Tests/MyLibraryTests/MyLibraryTests.swift
@@ -10,14 +10,16 @@
 //
 //===--------------------------------------------------------------------
 
+import Testing
 @testable import MyLibrary
-import XCTest
 
-final class MyLibraryTests: XCTestCase {
-  func testEmail() throws {
+struct MyLibraryTests {
+  @Test func email() throws {
     let email = try Email("john.appleseed@apple.com")
-    XCTAssertEqual(email.description, "john.appleseed@apple.com")
+    #expect(email.description == "john.appleseed@apple.com")
 
-    XCTAssertThrowsError(try Email("invalid"))
+    #expect(throws: (any Error).self) {
+      try Email("invalid")
+    }
   }
 }


### PR DESCRIPTION
Update this small example package to showcase usage of Swift Testing instead of XCTest.

(This repo is linked from the [Swift Package Manager "Getting Started" page](https://www.swift.org/getting-started/library-swiftpm/) on Swift.org, which I'm in the process of updating in conjunction via a separate PR.)